### PR TITLE
Extend ItemSearch to Collection and ItemCollection

### DIFF
--- a/stac_static/search.py
+++ b/stac_static/search.py
@@ -179,7 +179,7 @@ class ItemSearch:
         filter: Optional[FilterLike] = None,
         filter_lang: Optional[FilterLangLike] = None,
     ):
-        if isinstance(catalog, pystac.Catalog):
+        if isinstance(catalog, (pystac.Catalog, pystac.Collection, pystac.ItemCollection)):
             self.df = to_geodataframe(catalog)
         else:
             self.df = catalog

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,11 @@ def test_case_1(request):
 
 @pytest.fixture(scope="module")
 def planet_disaster():
-    """planet_disaster as a catalog"""
+    """planet_disaster as a collection"""
     URL = here / "data-files" / "planet-disaster" / "collection.json"
     return pystac.read_file(URL)
+
+
+@pytest.fixture(scope="module")
+def item_collection(planet_disaster):
+    return pystac.ItemCollection(items=list(planet_disaster.get_items(recursive=True)))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -78,3 +78,8 @@ def test_filter(test_case_1, filter, n):
 def test_datetime_params(value, start, end, planet_disaster):
     result = search(planet_disaster, datetime=value)
     assert result._parameters["datetime"] == (start, end)
+
+
+def test_item_collection_eo(item_collection):
+    result = search(item_collection, filter="eo:cloud_cover < 10")
+    assert result.matched() == 4


### PR DESCRIPTION
Many thanks for this very useful package!

This is a modest proposal to extend search function to pystac Collection and ItemCollection classes, as function `to_geodataframe` already accepts both classes in addition to pystac.Catalog.

My use case is that I would use a locally saved ItemCollection, but one could also think of re-using the search result for another search to progressively narrow down the results.
